### PR TITLE
Implement and refine documentation

### DIFF
--- a/src/HiddenFiles.jl
+++ b/src/HiddenFiles.jl
@@ -4,6 +4,19 @@ module HiddenFiles
 export ishidden
 
 
+"""
+```julia
+ishidden(f::AbstractString)
+```
+
+Check if a file or directory is hidden.
+
+!!! note
+    On macOS and BSD, this function will follow symlinks.
+"""
+ishidden
+
+
 @static if Sys.isunix()
     _ishidden_unix(f::AbstractString) = startswith(basename(f), '.')
     


### PR DESCRIPTION
Add sufficient documentation to this package

Closes #4.

To do:
  - [ ] Add docstrings to relevant functions (presumably just the one)
  - [ ] Add OS-specific notes
  - [ ] Ensure internal functions are well documented by way of docstrings and comments
    - [ ] Add parametric comments to C calls
  - [ ] Customise documenter output