### PR TITLE
Draft: Identify macOS UNIX-specific system directories

### DIFF
--- a/src/utils/darwin.jl
+++ b/src/utils/darwin.jl
@@ -199,7 +199,9 @@ end
 #===============================================#
 
 # https://developer.apple.com/documentation/coreservices/lsiteminfoflags/klsiteminfoisinvisible
+# TODO: convert this to enum: https://developer.apple.com/documentation/coreservices/lsiteminfoflags: https://github.com/phracker/MacOSX-SDKs/blob/041600eda65c6a668f66cb7d56b7d1da3e8bcc93/MacOSX10.6.sdk/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Headers/LSInfo.h#L95-L111
 const KLS_ITEM_INFO_IS_INVISIBLE = 0x00000040
+
 # https://developer.apple.com/documentation/coreservices/1429609-anonymous/kisinvisible
 const K_IS_INVISIBLE = 0x00000040
 
@@ -208,26 +210,30 @@ const K_CF_URL_POSIX_PATH_STYLE = zero(Int8)
 
 # https://developer.apple.com/documentation/corefoundation/1543250-cfurlcreatewithfilesystempath
 function _cf_url_create_with_file_system_path(cfstr::Cstring, is_directory::Bool, path_style::Integer = K_CF_URL_POSIX_PATH_STYLE)
+    # TODO: handle error codes
     # CFURLRef CFURLCreateWithFileSystemPath(CFAllocatorRef allocator, CFStringRef filePath, CFURLPathStyle pathStyle, Boolean isDirectory);
     url_ref = ccall(:CFURLCreateWithFileSystemPath, Ptr{UInt32},
                     (Ptr{Cvoid}, Cstring, Int32, Bool),
                     C_NULL, cfstr, path_style, is_directory)
     return url_ref
 end
-# _cf_url_create_with_file_system_path(f::AbstractString, path_style::Integer = K_CF_URL_POSIX_PATH_STYLE, str_encoding::Unsigned = CF_STRING_ENCODING) = 
-#     _cf_url_create_with_file_system_path(_cf_string_create_with_cstring(f, str_encoding), isdir(f), path_style)
-    
 
 # https://developer.apple.com/documentation/coreservices/lsiteminforecord
 function _ls_item_info_record()
+    @warn "LSItemInfoRecord has been deprecated since macOS 10.11"
     error("not yet implemented")
 end
 
 # https://developer.apple.com/documentation/coreservices/lsrequestedinfo/klsrequestallflags
 const K_LS_REQUEST_ALL_FLAGS = 0x00000010
+# TODO: convert this to enum: https://developer.apple.com/documentation/coreservices/lsrequestedinfo: https://github.com/phracker/MacOSX-SDKs/blob/041600eda65c6a668f66cb7d56b7d1da3e8bcc93/MacOSX10.6.sdk/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Headers/LSInfo.h#L83-L93
 
 # https://developer.apple.com/documentation/coreservices/1445685-lscopyiteminfoforurl
 function _ls_copy_item_info_for_url(url_ref::Ptr{UInt32}, requested_info::Unsigned = K_LS_REQUEST_ALL_FLAGS)
+    # TODO: handle error codes
+    requested_info == K_LS_REQUEST_ALL_FLAGS && @warn "kLSRequestAllFlags has been deprecated since macOS 10.11"
+    requested_info == KLS_ITEM_INFO_IS_INVISIBLE && @warn "kLSItemInfoIsInvisible has been deprecated since macOS 10.11; ensure you are using kIsInvisible instead"
+    @warn "LSCopyItemInfoForURL has been deprecated since macOS 10.11"
     # buf = Vector{UInt32}(undef, 100)
     buf = zeros(UInt32, 100)
     # OSStatus LSCopyItemInfoForURL(CFURLRef inURL, LSRequestedInfo inWhichInfo, LSItemInfoRecord *outItemInfo);
@@ -235,11 +241,6 @@ function _ls_copy_item_info_for_url(url_ref::Ptr{UInt32}, requested_info::Unsign
                 (Ptr{UInt32}, UInt32, Ptr{Cvoid}),
                 url_ref, requested_info, buf)
     return buf
-end
-
-# https://developer.apple.com/documentation/coreservices/lsiteminfoflags
-function _ls_item_info_flags()
-    error("not yet implemented")
 end
 
 function _isinvisible_alt(f::AbstractString, str_encoding::Unsigned = CF_STRING_ENCODING, path_style::Integer = K_CF_URL_POSIX_PATH_STYLE)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,11 +25,26 @@ using Test
                 
                 # Case 2: UNIX-specific directories
                 # TODO: complete this case
-                @test HiddenFiles.ishidden("/bin/")
-                @test HiddenFiles.ishidden("/dev/")
-                @test HiddenFiles.ishidden("/usr/")
-                @test !HiddenFiles.ishidden("/tmp/")
-                
+                @test HiddenFiles.ishidden("/bin")
+                @test HiddenFiles.ishidden("/dev")
+                @test HiddenFiles.ishidden("/dev")
+                @test HiddenFiles.ishidden("/etc")
+                @test HiddenFiles.ishidden("/sbin")
+                @test HiddenFiles.ishidden("/sbin")
+                @test HiddenFiles.ishidden("/tmp")
+                @test HiddenFiles.ishidden("/usr")
+                @test HiddenFiles.ishidden("/var")
+                @test HiddenFiles._isinvisible_alt("/bin")
+                @test HiddenFiles._isinvisible_alt("/dev")
+                @test HiddenFiles._isinvisible_alt("/dev")
+                @test HiddenFiles._isinvisible_alt("/etc")
+                @test HiddenFiles._isinvisible_alt("/sbin")
+                @test HiddenFiles._isinvisible_alt("/sbin")
+                @test HiddenFiles._isinvisible_alt("/tmp")
+                @test HiddenFiles._isinvisible_alt("/usr")
+                @test HiddenFiles._isinvisible_alt("/var")
+                @test !HiddenFiles._isinvisible_alt("/bin/bash")
+
                 # Case 3: Explicitly hidden files and directories
                 @test HiddenFiles._isinvisible("/Volumes")
                 @test ishidden("/Volumes")
@@ -41,7 +56,8 @@ using Test
                 @test ishidden("/System/Applications/Utilities/Terminal.app/Contents/")  # This should be the same as above, as we expand all paths using realpath
                 @test !HiddenFiles._ispackage_or_bundle("/System/Applications/Utilities/Terminal.app/Contents/")
                 @test HiddenFiles._exists_inside_package_or_bundle("/System/Applications/Utilities/Terminal.app/Contents/")
-                @test !HiddenFiles._exists_inside_package_or_bundle("/bin/")
+                @test !HiddenFiles._exists_inside_package_or_bundle("/bin")
+                @test !HiddenFiles._exists_inside_package_or_bundle("/tmp")
                 f = String(rand(Char, 32))  # this path shouldn't exist
                 cfstr_nonexistent = HiddenFiles._cfstring_create_with_cstring(f)
                 @test_throws Exception HiddenFiles._mditem_create(cfstr_nonexistent)


### PR DESCRIPTION
According to [this](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#//apple_ref/doc/uid/TP40010672-CH2-SW7), there as some UNIX-specific system directories that exist as part of the BSD-layer which are important and hidden by default.  We need some way of identifying these.

Addresses #1.

[Related question](https://apple.stackexchange.com/q/448174/366960).