### PR TITLE
Ensure directory references are hidden

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HiddenFiles"
 uuid = "d01c2003-3cc0-4d61-912c-b250feb01c5b"
 authors = ["Jake Ireland <jakewilliami@icloud.com> and contributors"]
-version = "0.1.2"
+version = "0.1.3"
 
 [compat]
 julia = "1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -131,4 +131,13 @@ using Test
         # ishidden calls to PathStruct
         @test_throws Union{Base.IOError, SystemError} ishidden(f)
     end
+
+    @testset "HiddenFiles.jl—Directory references" begin
+        @test HiddenFiles.ishidden(".")
+        @test HiddenFiles.ishidden("/bin/.")
+        @test HiddenFiles.ishidden(expanduser("~/../."))
+        @test HiddenFiles.ishidden("..")
+        @test HiddenFiles.ishidden(expanduser("~/.."))
+        @test HiddenFiles.ishidden("/bin/..")
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -133,11 +133,11 @@ using Test
     end
 
     @testset "HiddenFiles.jl—Directory references" begin
+        d = homedir()
         @test HiddenFiles.ishidden(".")
-        @test HiddenFiles.ishidden("/bin/.")
-        @test HiddenFiles.ishidden(expanduser("~/../."))
+        @test HiddenFiles.ishidden(joinpath(d, "."))
+        @test HiddenFiles.ishidden(joinpath(d, "..", "."))
         @test HiddenFiles.ishidden("..")
-        @test HiddenFiles.ishidden(expanduser("~/.."))
-        @test HiddenFiles.ishidden("/bin/..")
+        @test HiddenFiles.ishidden(joinpath(d, ".."))
     end
 end


### PR DESCRIPTION
They really exist on the file system so they should not just be treated as links and expanded.

Closes #24.